### PR TITLE
Automating everything with automation_script.sh

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_SERVER_URL="http://localhost:80/api"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ mobile/.expo
 
 /terraform/terraform.tfstate*
 /terraform/.terraform*
+
+**/hosts

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+# ---------------------------- ansible playbooks explanation -----------------------------
+restaurant-app
+├── ansible
+│   ├── main.yml               # Playbook to be executed on the maintenance instance
+│   ├── hosts                  # Inventory for the maintenance instance
+│   └── roles ...              # Other Ansible roles
+└── ansible_maintenance
+    ├── main.yml               # Playbook to run from your machine
+    └── hosts                  # Inventory for the maintenance instance
+
+
+
+# ----------------------- explanation of dynamic-inventory-script --------------------------
+
+1. Installing jq, a JSON processor, if it is not already installed (supports Ubuntu/Debian and macOS).
+2. Deploying infrastructure using Terraform by running terraform init, valide, plan and apply.
+3. Extracting Terraform outputs (specifically IP addresses) for the deployed infrastructure.
+4. Dynamically generating an Ansible inventory file (hosts) based on the IP addresses returned by Terraform. This inventory is used to configure remote machines with Ansible.
+5. 
+6. 
+
+
+
 # -------docker compose--------
 
 docker-compose build 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ restaurant-app
 ├── ansible
 │   ├── main.yml               # Playbook to be executed on the maintenance instance
 │   ├── hosts                  # Inventory for the maintenance instance
-│   └── roles ...              # Other Ansible roles
+│   └── roles ...              # Roles
 └── ansible_maintenance
     ├── main.yml               # Playbook to run from your machine
     └── hosts                  # Inventory for the maintenance instance
@@ -15,9 +15,9 @@ restaurant-app
 1. Installing jq, a JSON processor, if it is not already installed (supports Ubuntu/Debian and macOS).
 2. Deploying infrastructure using Terraform by running terraform init, valide, plan and apply.
 3. Extracting Terraform outputs (specifically IP addresses) for the deployed infrastructure.
-4. Dynamically generating an Ansible inventory file (hosts) based on the IP addresses returned by Terraform. This inventory is used to configure remote machines with Ansible.
-5. 
-6. 
+4. Dynamically generating an Ansible inventory file (hosts) based on the IP addresses returned by Terraform. This inventory is used to configure the private instances throuth the maintenace host
+5. Dynamically generating an Ansible inventory file (hosts) for the maintenance host
+6. Runs the maintenance_ansible playbook
 
 
 

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,10 +1,10 @@
 [frontend]
-frontend ansible_host=10.0.2.136 port=3000 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+frontend ansible_host=10.0.2.159 port=3000 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
 
 [backend]
-items ansible_host=10.0.2.114 port=3003 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
-auth ansible_host=10.0.2.97 port=3001 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
-discounts ansible_host=10.0.2.25 port=3002 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+items ansible_host=10.0.2.114 port=3003 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
+auth ansible_host=10.0.2.231 port=3001 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
+discounts ansible_host=10.0.2.25 port=3002 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
 
 [haproxy]
-haproxy ansible_host=18.169.163.70 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+haproxy ansible_host=18.169.163.70 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,12 +1,10 @@
-
 [frontend]
-frontend ansibe_host=private_ip port=3000 ansible_user=ubuntu ansible_ssh_private_key_file=<key path>
+frontend ansible_host=10.0.2.136 port=3000 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
 
 [backend]
-items ansibe_host=private_ip port=3003 ansible_user=ubuntu ansible_ssh_private_key_file=<key path>
-auth ansibe_host=private_ip port=3001 ansible_user=ubuntu ansible_ssh_private_key_file=<key path>
-discounts ansibe_host=private_ip port=3002 ansible_user=ubuntu ansible_ssh_private_key_file=<key path>
+items ansible_host=10.0.2.114 port=3003 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+auth ansible_host=10.0.2.97 port=3001 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+discounts ansible_host=10.0.2.25 port=3002 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
 
 [haproxy]
-hap1 ansibe_host=public_ip ansible_user= ansible_ssh_private_key_file=<key path>
-
+haproxy ansible_host=18.169.163.70 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -1,9 +1,9 @@
-- host: haproxy
+- hosts: haproxy
   roles:
     - haproxy
   become: yes
 
-- host: frontend
+- hosts: frontend
   roles:
     - frontend
   become: yes

--- a/ansible/roles/backend/tasks/main.yml
+++ b/ansible/roles/backend/tasks/main.yml
@@ -71,6 +71,12 @@
       - docker-compose.yml
     state: absent
 
+- name: Remove existing conflicting containers
+  community.docker.docker_container:
+    name: "{{ inventory_hostname }}"
+    state: absent
+
+
 - name: Build and Compose containers
   community.docker.docker_compose_v2:
     project_src: /home/ubuntu/restaurant-app

--- a/ansible/roles/backend/tasks/main.yml
+++ b/ansible/roles/backend/tasks/main.yml
@@ -1,24 +1,70 @@
-- name: Install Docker
+- name: Update apt package index
   apt:
-    name: docker
-    state: present
     update_cache: yes
-  become: true
+
+- name: Install required packages for Docker installation
+  apt:
+    name:
+      - ca-certificates
+      - curl
+    state: present
+
+- name: Create the /etc/apt/keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Add Docker's official GPG key
+  get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+
+- name: Update the apt package index again
+  apt:
+    update_cache: yes
+
+
+- name: Add the Docker APT repository
+  lineinfile:
+    path: /etc/apt/sources.list.d/docker.list
+    line: "deb [arch={{ ansible_architecture }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    create: yes
+    mode: '0644'
+
+- name: Update apt package index again after adding Docker repository
+  apt:
+    update_cache: yes
+
+- name: Install Docker using the convenience script
+  shell: curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+  args:
+    executable: /bin/bash
+
+- name: Start and enable Docker service
+  systemd:
+    name: docker
+    state: started
+    enabled: yes
+
 
 - name: Clone repository
   git:
     repo: https://github.com/Tassianna/restaurant-app.git
-    dest: ./
+    dest: /home/ubuntu/restautant-app
     clone: yes
+    force: yes
     update: true
 
 # inventory_hostname
 - name: Copy Docker Compose file for relevant service and overwrite original
   copy:
     src: "../templates/docker-compose-{{inventory_hostname}}.yml"
-    dest: "~/restaurant-app/docker-compose.yml"
+    dest: "/home/ubuntu/restaurant-app/docker-compose.yml"
 
 - name: Build and Compose containers
-  docker_compose:
-    project_src: ~/restautant-app
-    state: present
+  community.docker.docker_compose_v2:
+    project_src: /home/ubuntu/restaurant-app
+    files: 
+      - docker-compose.yml

--- a/ansible/roles/backend/tasks/main.yml
+++ b/ansible/roles/backend/tasks/main.yml
@@ -63,6 +63,14 @@
     src: "../templates/docker-compose-{{inventory_hostname}}.yml"
     dest: "/home/ubuntu/restaurant-app/docker-compose.yml"
 
+#docker compose down for cleaning up:
+- name: Bring down Docker Compose
+  community.docker.docker_compose_v2:
+    project_src: /home/ubuntu/restaurant-app
+    files:
+      - docker-compose.yml
+    state: absent
+
 - name: Build and Compose containers
   community.docker.docker_compose_v2:
     project_src: /home/ubuntu/restaurant-app

--- a/ansible/roles/backend/tasks/main.yml
+++ b/ansible/roles/backend/tasks/main.yml
@@ -52,7 +52,7 @@
 - name: Clone repository
   git:
     repo: https://github.com/Tassianna/restaurant-app.git
-    dest: /home/ubuntu/restautant-app
+    dest: /home/ubuntu/restaurant-app
     clone: yes
     force: yes
     update: true
@@ -63,18 +63,14 @@
     src: "../templates/docker-compose-{{inventory_hostname}}.yml"
     dest: "/home/ubuntu/restaurant-app/docker-compose.yml"
 
-#docker compose down for cleaning up:
-- name: Bring down Docker Compose
-  community.docker.docker_compose_v2:
-    project_src: /home/ubuntu/restaurant-app
-    files:
-      - docker-compose.yml
-    state: absent
-
-- name: Remove existing conflicting containers
-  community.docker.docker_container:
-    name: "{{ inventory_hostname }}"
-    state: absent
+#docker compose down for cleaning up: 
+#uncomment if we want to compose down for some reason
+#- name: Bring down Docker Compose
+#  community.docker.docker_compose_v2:
+#    project_src: /home/ubuntu/restaurant-app
+#    files:
+#      - docker-compose.yml
+#    state: absent
 
 
 - name: Build and Compose containers

--- a/ansible/roles/backend/templates/docker-compose-auth.yml
+++ b/ansible/roles/backend/templates/docker-compose-auth.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   auth:
     build:
-      context: home/ubuntu/restaurant-app/backend/auth
+      context: ./backend/auth
       dockerfile: Dockerfile
     container_name: auth
     ports:

--- a/ansible/roles/backend/templates/docker-compose-auth.yml
+++ b/ansible/roles/backend/templates/docker-compose-auth.yml
@@ -1,9 +1,9 @@
 version: "3.7"
 
 services:
-  auth1:
+  auth:
     build:
-      context: ./backend/auth
+      context: home/ubuntu/restaurant-app/backend/auth
       dockerfile: Dockerfile
     container_name: auth
     ports:

--- a/ansible/roles/backend/templates/docker-compose-discounts.yml
+++ b/ansible/roles/backend/templates/docker-compose-discounts.yml
@@ -2,9 +2,9 @@ version: "3.7"
 
 services:
 
-  discounts1:
+  discounts:
     build:
-      context: ./backend/discounts
+      context: home/ubuntu/restaurant-app/backend/discounts
       dockerfile: Dockerfile
     container_name: discount
     ports:

--- a/ansible/roles/backend/templates/docker-compose-discounts.yml
+++ b/ansible/roles/backend/templates/docker-compose-discounts.yml
@@ -6,6 +6,6 @@ services:
     build:
       context: ./backend/discounts
       dockerfile: Dockerfile
-    container_name: discount
+    container_name: discounts
     ports:
       - "3002:3002"

--- a/ansible/roles/backend/templates/docker-compose-discounts.yml
+++ b/ansible/roles/backend/templates/docker-compose-discounts.yml
@@ -4,7 +4,7 @@ services:
 
   discounts:
     build:
-      context: home/ubuntu/restaurant-app/backend/discounts
+      context: ./backend/discounts
       dockerfile: Dockerfile
     container_name: discount
     ports:

--- a/ansible/roles/backend/templates/docker-compose-items.yml
+++ b/ansible/roles/backend/templates/docker-compose-items.yml
@@ -4,7 +4,7 @@ services:
 
   items:
     build:
-      context: home/ubuntu/restaurant-app/backend/items
+      context: ./backend/items
       dockerfile: Dockerfile
     container_name: items
     ports:

--- a/ansible/roles/backend/templates/docker-compose-items.yml
+++ b/ansible/roles/backend/templates/docker-compose-items.yml
@@ -2,9 +2,9 @@ version: "3.7"
 
 services:
 
-  items1:
+  items:
     build:
-      context: ./backend/items
+      context: home/ubuntu/restaurant-app/backend/items
       dockerfile: Dockerfile
     container_name: items
     ports:

--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -62,6 +62,15 @@
     src: ../templates/docker-compose.yml
     dest: /home/ubuntu/restaurant-app/docker-compose.yml
 
+#docker compose down for cleaning up:
+- name: Bring down Docker Compose
+  community.docker.docker_compose_v2:
+    project_src: /home/ubuntu/restaurant-app
+    files:
+      - docker-compose.yml
+    state: absent
+
+
 - name: Build and Compose containers
   community.docker.docker_compose_v2:
     project_src: /home/ubuntu/restaurant-app

--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -1,15 +1,60 @@
-- name: Install docker
+- name: Update apt package index
   apt:
-    name: "{{ packages }}"
-    state: present
     update_cache: yes
-  become: true
 
-- name: Clone GitHub repo
+- name: Install required packages for Docker installation
+  apt:
+    name:
+      - ca-certificates
+      - curl
+    state: present
+
+- name: Create the /etc/apt/keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Add Docker's official GPG key
+  get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+
+- name: Update the apt package index again
+  apt:
+    update_cache: yes
+
+
+- name: Add the Docker APT repository
+  lineinfile:
+    path: /etc/apt/sources.list.d/docker.list
+    line: "deb [arch={{ ansible_architecture }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    create: yes
+    mode: '0644'
+
+- name: Update apt package index again after adding Docker repository
+  apt:
+    update_cache: yes
+
+- name: Install Docker using the convenience script
+  shell: curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+  args:
+    executable: /bin/bash
+
+- name: Start and enable Docker service
+  systemd:
+    name: docker
+    state: started
+    enabled: yes
+
+
+- name: Clone repository
   git:
     repo: https://github.com/Tassianna/restaurant-app.git
-    dest: /home/ubuntu/
+    dest: /home/ubuntu/restaurant-app
     clone: yes
+    force: yes
     update: true
 
 - name: Replace docker-compose file
@@ -17,7 +62,8 @@
     src: ../templates/docker-compose.yml
     dest: /home/ubuntu/restaurant-app/docker-compose.yml
 
-- name: Run docker-compose up
-  docker_compose:
-    project_src: /home/ubuntu/restaurant-app/
-    state: present
+- name: Build and Compose containers
+  community.docker.docker_compose_v2:
+    project_src: /home/ubuntu/restaurant-app
+    files: 
+      - docker-compose.yml

--- a/ansible/roles/frontend/tasks/main.yml
+++ b/ansible/roles/frontend/tasks/main.yml
@@ -58,17 +58,18 @@
     update: true
 
 - name: Replace docker-compose file
-  template:
+  copy:
     src: ../templates/docker-compose.yml
     dest: /home/ubuntu/restaurant-app/docker-compose.yml
 
-#docker compose down for cleaning up:
-- name: Bring down Docker Compose
-  community.docker.docker_compose_v2:
-    project_src: /home/ubuntu/restaurant-app
-    files:
-      - docker-compose.yml
-    state: absent
+#docker compose down for cleaning up: 
+#uncomment if we want to compose down for some reason
+#- name: Bring down Docker Compose
+#  community.docker.docker_compose_v2:
+#    project_src: /home/ubuntu/restaurant-app
+#    files:
+#      - docker-compose.yml
+#    state: absent
 
 
 - name: Build and Compose containers

--- a/ansible/roles/frontend/templates/docker-compose.yml
+++ b/ansible/roles/frontend/templates/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   frontend:
     build:
-      context: home/ubuntu/restaurant-app/client
+      context: ./client
       dockerfile: Dockerfile
     container_name: frontend
     ports:

--- a/ansible/roles/frontend/templates/docker-compose.yml
+++ b/ansible/roles/frontend/templates/docker-compose.yml
@@ -2,10 +2,10 @@ version: "3.7"
 
 services:
 
-  frontend1:
+  frontend:
     build:
-      context: ./client
+      context: home/ubuntu/restaurant-app/client
       dockerfile: Dockerfile
-    container_name: client
+    container_name: frontend
     ports:
       - 3000:80

--- a/ansible/roles/frontend/vars/main.yml
+++ b/ansible/roles/frontend/vars/main.yml
@@ -1,2 +1,0 @@
-packages:
-  - docker

--- a/ansible/roles/haproxy/tasks/main.yml
+++ b/ansible/roles/haproxy/tasks/main.yml
@@ -1,28 +1,73 @@
-- name: Install Docker
+- name: Update apt package index
   apt:
-    name: docker
-    state: present
     update_cache: yes
-  become: true
 
+- name: Install required packages for Docker installation
+  apt:
+    name:
+      - ca-certificates
+      - curl
+    state: present
+
+- name: Create the /etc/apt/keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Add Docker's official GPG key
+  get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+
+- name: Update the apt package index again
+  apt:
+    update_cache: yes
+
+
+- name: Add the Docker APT repository
+  lineinfile:
+    path: /etc/apt/sources.list.d/docker.list
+    line: "deb [arch={{ ansible_architecture }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+    create: yes
+    mode: '0644'
+
+- name: Update apt package index again after adding Docker repository
+  apt:
+    update_cache: yes
+
+- name: Install Docker using the convenience script
+  shell: curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
+  args:
+    executable: /bin/bash
+
+- name: Start and enable Docker service
+  systemd:
+    name: docker
+    state: started
+    enabled: yes
 - name: Clone repository
   git:
     repo: https://github.com/Tassianna/restaurant-app.git
-    dest: ./
+    dest: /home/ubuntu/restaurant-app
     clone: yes
+    force: yes
     update: true
 
 # inventory_hostname
 - name: Copy Docker Compose file for relevant service and overwrite original
   copy:
     src: "../templates/docker-compose.yml"
-    dest: "~/restaurant-app/docker-compose.yml"
+    dest: "/home/ubuntu/restaurant-app/docker-compose.yml"
 
 - name: Copy Docker haproxy file
   copy:
     src: "../templates/haproxy.tpl"
-    dest: "~/restaurant-app/haproxy.cfg"
+    dest: "/home/ubuntu/restaurant-app/haproxy.cfg"
 
 - name: Build and Compose containers
-  docker_compose:
-    project_src: ~/restautant-app
+  community.docker.docker_compose_v2:
+    project_src: /home/ubuntu/restaurant-app
+    files: 
+      - docker-compose.yml

--- a/ansible/roles/haproxy/templates/haproxy.tpl
+++ b/ansible/roles/haproxy/templates/haproxy.tpl
@@ -31,12 +31,12 @@ frontend http-in
 
 {% for host in groups[backend] %}
 # Backend for the frontend service
-backend {{ hostvars[host][‘inventory_host’] }}-backend
-    server http://{{ hostvars[host][‘ansible_host’] }}:{{ hostvars[host].port }}
+backend {{ hostvars[host]['inventory_host'] }}-backend
+    server {{ hostvars[host]['inventory_hostname'] }} {{ hostvars[host]['ansible_host'] }}:{{ hostvars[host]['port'] }}
 {% endfor %}
 
 {% for host in groups[frontend] %}
 # Backend for the frontend service
-backend {{ hostvars[host][‘inventory_host’] }}-backend
-    server http://{{ hostvars[host][‘ansible_host’] }}:{{ hostvars[host].port }}
+backend {{ hostvars[host]['inventory_host'] }}-backend
+    server {{ hostvars[host]['inventory_hostname'] }} {{ hostvars[host]['ansible_host'] }}:{{ hostvars[host]['port'] }}
 {% endfor %}

--- a/ansible_maintenance/ansible.cfg
+++ b/ansible_maintenance/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory = hosts
+host_key_checking = False

--- a/ansible_maintenance/hosts
+++ b/ansible_maintenance/hosts
@@ -1,0 +1,2 @@
+[maintenance]
+maintenance ansible_host=18.135.102.213 ansible_user=ubuntu ansible_ssh_private_key_file=/Users/tassianna/Desktop/london_key.pem

--- a/ansible_maintenance/main.yml
+++ b/ansible_maintenance/main.yml
@@ -20,6 +20,8 @@
         src: /Users/tassianna/Desktop/london_key.pem  
         dest: /home/ubuntu/london_key.pem
         mode: '0600'  # Set permissions for the key
+    
+    # TODO: chown ubuntu:ubuntu /home/ubuntu/london_key.pem
 
     #- name: Run the Ansible playbook from the cloned repository
     #  command: ansible-playbook ./restaurant-app/ansible/main.yml  

--- a/ansible_maintenance/main.yml
+++ b/ansible_maintenance/main.yml
@@ -13,17 +13,20 @@
       git:
         repo: https://github.com/Tassianna/restaurant-app.git  # Replace with your repo URL
         dest: /home/ubuntu/restaurant-app # Specify the path where you want to clone the repo
+        clone: yes
         force: yes  # Ensures the repo is cloned even if it already exists
+        update: true
 
     - name: Copy london.key to maintenance instance
       copy:
-        src: /Users/tassianna/Desktop/london_key.pem  
+        src: "{{ local_key }}" # this is passed via playbook command in automated script
         dest: /home/ubuntu/london_key.pem
         mode: '0600'  # Set permissions for the key
     
     # TODO: chown ubuntu:ubuntu /home/ubuntu/london_key.pem
 
-    #- name: Run the Ansible playbook from the cloned repository
-    #  command: ansible-playbook ./restaurant-app/ansible/main.yml  
-    #  args:
-    #    chdir: ubuntu/home/restaurant-app        
+    - name: Run the Ansible playbook from the cloned repository
+      command: ansible-playbook ./ansible/main.yml  
+      args:
+        chdir: /home/ubuntu/restaurant-app  
+

--- a/ansible_maintenance/main.yml
+++ b/ansible_maintenance/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Setup Maintenance Instance
+  hosts: maintenance
+  become: yes  # Use sudo
+  tasks:
+    - name: Ensure Ansible is installed
+      apt:
+        name: ansible
+        state: present
+        update_cache: yes
+
+    - name: Clone the Git repository
+      git:
+        repo: https://github.com/Tassianna/restaurant-app.git  # Replace with your repo URL
+        dest: /home/ubuntu/restaurant-app # Specify the path where you want to clone the repo
+        force: yes  # Ensures the repo is cloned even if it already exists
+
+    - name: Copy london.key to maintenance instance
+      copy:
+        src: /Users/tassianna/Desktop/london_key.pem  
+        dest: /home/ubuntu/london_key.pem
+        mode: '0600'  # Set permissions for the key
+
+    #- name: Run the Ansible playbook from the cloned repository
+    #  command: ansible-playbook ./restaurant-app/ansible/main.yml  
+    #  args:
+    #    chdir: ubuntu/home/restaurant-app        

--- a/automation_script.sh
+++ b/automation_script.sh
@@ -63,15 +63,15 @@ maintenance_ip=$(terraform output -json maintenance_ip | jq -r)
 #Step 3: Generate Ansible inventory
 cat > ../ansible/hosts <<EOF
 [frontend]
-frontend ansible_host=$frontend_ip port=3000 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+frontend ansible_host=$frontend_ip port=3000 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
 
 [backend]
-items ansible_host=$items_service_ip port=3003 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
-auth ansible_host=$auth_service_ip port=3001 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
-discounts ansible_host=$discounts_service_ip port=3002 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+items ansible_host=$items_service_ip port=3003 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
+auth ansible_host=$auth_service_ip port=3001 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
+discounts ansible_host=$discounts_service_ip port=3002 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
 
 [haproxy]
-haproxy ansible_host=$haproxy_ip ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+haproxy ansible_host=$haproxy_ip ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
 EOF
 
 echo "Ansible inventory file created: hosts"

--- a/automation_script.sh
+++ b/automation_script.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# In this step we install jq:
+# jq is a lightweight and powerful command-line JSON processor 
+# that is required to parse the JSON output from Terraform.
+# What we do is to check if the jq is installed and if not
+# installing it depending on the OS. We only added mac and linux os.
+
+# Step 0: Check if jq is installed, and install if not
+echo "Checking if jq is installed..."
+
+if ! command -v jq &> /dev/null
+then
+    echo "jq not found, attempting to install..."
+
+    # Detect the operating system and install jq accordingly
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        # For Ubuntu/Debian-based systems
+        echo "Detected Ubuntu/Debian-based Linux. Installing jq..."
+        sudo apt-get update && sudo apt-get install -y jq
+
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        # For macOS
+        echo "Detected macOS. Installing jq via Homebrew..."
+        if ! command -v brew &> /dev/null
+        then
+            echo "Homebrew not found. Please install Homebrew first from https://brew.sh/"
+            exit 1
+        fi
+        brew install jq
+
+    else
+        echo "Unsupported OS. Please install jq manually."
+        exit 1
+    fi
+fi
+
+# Step 1: Run Terraform apply to deploy resources and generate outputs
+echo "Initializing Terraform..."
+cd ./terraform || exit 1  # Ensure script stops if directory change fails
+terraform init || exit 1  # Exit if init fails
+
+echo "Validating Terraform configuration..."
+terraform validate || exit 1  # Exit if validation fails
+
+echo "Generating Terraform plan..."
+terraform plan || exit 1  # Exit if planning fails
+
+echo "Applying Terraform plan..."
+terraform apply -auto-approve || exit 1  # Exit if apply fails
+
+
+pwd
+# Step 2:  Extract Terraform outputs
+frontend_ip=$(terraform output -json frontend_ip | jq -r)
+items_service_ip=$(terraform output -json items_service_ip | jq -r)
+auth_service_ip=$(terraform output -json auth_service_ip | jq -r)
+discounts_service_ip=$(terraform output -json discounts_service_ip | jq -r)
+haproxy_ip=$(terraform output -json haproxy_ip | jq -r)
+maintenance_ip=$(terraform output -json maintenance_ip | jq -r)
+
+
+#Step 3: Generate Ansible inventory
+cat > ../ansible/hosts <<EOF
+[frontend]
+frontend ansible_host=$frontend_ip port=3000 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+
+[backend]
+items ansible_host=$items_service_ip port=3003 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+auth ansible_host=$auth_service_ip port=3001 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+discounts ansible_host=$discounts_service_ip port=3002 ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+
+[haproxy]
+haproxy ansible_host=$haproxy_ip ansible_user=ubuntu ansible_ssh_private_key_file=/ubuntu/home/london_key.pem
+EOF
+
+echo "Ansible inventory file created: hosts"
+
+# Step 4: Generate Ansible inventory for maintenance
+# TODO: instead of /Users/tassianna/Desktop/london_key.pem we can add a variable!
+cat > ../ansible_maintenance/hosts <<EOF
+[maintenance]
+maintenance ansible_host=$maintenance_ip ansible_user=ubuntu ansible_ssh_private_key_file=/Users/tassianna/Desktop/london_key.pem
+EOF
+
+echo "Ansible_maintenance inventory file created: hosts"
+
+# Step 5: Run ansible_maintenance playbook
+
+# go back to restaurant-app folder
+cd ..
+cd ansible_maintenance
+ansible-playbook -i hosts main.yml
+

--- a/automation_script.sh
+++ b/automation_script.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 
+# Load the .env file
+export $(grep -v '^#' .env | xargs)
+
 # In this step we install jq:
 # jq is a lightweight and powerful command-line JSON processor 
 # that is required to parse the JSON output from Terraform.
 # What we do is to check if the jq is installed and if not
 # installing it depending on the OS. We only added mac and linux os.
 
-# Step 0: Check if jq is installed, and install if not
-echo "Checking if jq is installed..."
+echo "#"
+echo "#"
+echo "#"
+echo "# Step 0: Check if jq is installed, and install if not"
+echo "#"
+echo "#"
+echo "#" 
+echo "# Checking if jq is installed..."
 
 if ! command -v jq &> /dev/null
 then
@@ -35,8 +44,14 @@ then
     fi
 fi
 
-# Step 1: Run Terraform apply to deploy resources and generate outputs
-echo "Initializing Terraform..."
+echo "#"
+echo "#"
+echo "#"
+echo "# Step 1: Run Terraform apply to deploy resources and generate outputs"
+echo "#"
+echo "#"
+echo "#" 
+echo "# Initializing Terraform..."
 cd ./terraform || exit 1  # Ensure script stops if directory change fails
 terraform init || exit 1  # Exit if init fails
 
@@ -49,9 +64,14 @@ terraform plan || exit 1  # Exit if planning fails
 echo "Applying Terraform plan..."
 terraform apply -auto-approve || exit 1  # Exit if apply fails
 
-
+echo "#"
+echo "#"
+echo "#"
+echo "# Step 2:  Extract Terraform outputs"
+echo "#"
+echo "#"
+echo "#" 
 pwd
-# Step 2:  Extract Terraform outputs
 frontend_ip=$(terraform output -json frontend_ip | jq -r)
 items_service_ip=$(terraform output -json items_service_ip | jq -r)
 auth_service_ip=$(terraform output -json auth_service_ip | jq -r)
@@ -59,8 +79,14 @@ discounts_service_ip=$(terraform output -json discounts_service_ip | jq -r)
 haproxy_ip=$(terraform output -json haproxy_ip | jq -r)
 maintenance_ip=$(terraform output -json maintenance_ip | jq -r)
 
+echo "#"
+echo "#"
+echo "#"
+echo "# Step 3: Generate Ansible inventory"
+echo "#"
+echo "#"
+echo "#" 
 
-#Step 3: Generate Ansible inventory
 cat > ../ansible/hosts <<EOF
 [frontend]
 frontend ansible_host=$frontend_ip port=3000 ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
@@ -74,21 +100,28 @@ discounts ansible_host=$discounts_service_ip port=3002 ansible_user=ubuntu ansib
 haproxy ansible_host=$haproxy_ip ansible_user=ubuntu ansible_ssh_private_key_file=/home/ubuntu/london_key.pem
 EOF
 
-echo "Ansible inventory file created: hosts"
+echo "# Ansible inventory file created: hosts"
 
 # Step 4: Generate Ansible inventory for maintenance
 # TODO: instead of /Users/tassianna/Desktop/london_key.pem we can add a variable!
 cat > ../ansible_maintenance/hosts <<EOF
 [maintenance]
-maintenance ansible_host=$maintenance_ip ansible_user=ubuntu ansible_ssh_private_key_file=/Users/tassianna/Desktop/london_key.pem
+maintenance ansible_host=$maintenance_ip ansible_user=ubuntu ansible_ssh_private_key_file=$LOCAL_KEY
 EOF
 
-echo "Ansible_maintenance inventory file created: hosts"
+echo "# Ansible_maintenance inventory file created: hosts"
 
-# Step 5: Run ansible_maintenance playbook
+echo "#"
+echo "#"
+echo "#"
+echo "# Step 5: Run ansible_maintenance playbook"
+echo "#"
+echo "#"
+echo "#" 
 
 # go back to restaurant-app folder
 cd ..
 cd ansible_maintenance
-ansible-playbook -i hosts main.yml
+ansible-playbook -i hosts main.yml --extra-vars "local_key=$LOCAL_KEY"
+
 

--- a/aws_configure.sh
+++ b/aws_configure.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+source .env
+
+echo "project initializing in Graces machine"
+
+echo "sign into desired AWS"
+
+aws configure set aws_access_key_id ${AWS_ACCESS_KEY} && \
+aws configure set aws_secret_access_key ${AWS_ACCESS_SECRET_KEY} && \
+aws configure set region ${AWS_REGION}

--- a/backend/discounts/Dockerfile
+++ b/backend/discounts/Dockerfile
@@ -20,7 +20,7 @@ RUN npm install --production \
 COPY . .
 
 # Expose the port
-EXPOSE 3001
+EXPOSE 3002
 
 # Start the application
 CMD ["node", "server.js"]

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -14,5 +14,5 @@ output "items_service_ip" {
     value = aws_instance.instance["items_service"].private_ip
 }
 output "frontend_ip" {
-    value = aws_instance.instance["frontend"].private_ip
+    value = aws_instance.instance["client"].private_ip
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -5,14 +5,14 @@ output "maintenance_ip" {
     value = aws_instance.instance["maintenance"].public_ip
 }
 output "auth_service_ip" {
-    value = aws_instance.instance["auth_service"].public_ip
+    value = aws_instance.instance["auth_service"].private_ip
 }
 output "discounts_service_ip" {
-    value = aws_instance.instance["discounts_service"].public_ip
+    value = aws_instance.instance["discounts_service"].private_ip
 }
 output "items_service_ip" {
-    value = aws_instance.instance["items_service"].public_ip
+    value = aws_instance.instance["items_service"].private_ip
 }
 output "frontend_ip" {
-    value = aws_instance.instance["frontend"].public_ip
+    value = aws_instance.instance["frontend"].private_ip
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -101,7 +101,7 @@ instances = {
         EOF
     }
 
-    frontend = {
+    client = {
         availability_zone           = "eu-west-2b"
         vpc_security_group          = false
         subnet                      = "private_subnet"


### PR DESCRIPTION
I created a script that 
1. Runs terraform
2. Parses output variables (IPs) into the inventories so we don't have to manually add them
3.  And runs the maintenance playbook
This playbook (ansible_maintenance) does this:
    - installs ansible in instance maint.
    - clones the git repo 
    - and save-copies the london.key into the instance
 
=> now we can either connect to the maintenance instance and run the ansible playbook
      or add an extra task in the ansible_maintenance (it is already there as comment) to run it automatically

check the README file

Graces changes;
ansible_maintenance/main.yml
- updated task of cloning repo to include clone and update flags
- replaced static local address key with reference to variable in local .env file
- fixed task to run main playbook from maintenance by correcting address and command 

gitignore
- added all hosts files 

automation_script.sh
- imported .env file for reference to local variables
- commented steps 
- replaced static reference to local key file with .env var 
- injected same var into ansible_maintenance call

aws configure bash script for ease 

